### PR TITLE
Add new parameter 'target_runlevel'.

### DIFF
--- a/builder/lxc/step_wait_init.go
+++ b/builder/lxc/step_wait_init.go
@@ -84,7 +84,8 @@ func (s *StepWaitInit) waitForInit(state multistep.StateBag, cancel <-chan struc
 
 		log.Printf("Current runlevel in container: '%s'", runlevel)
 
-		if runlevel == "N 3" {
+		targetRunlevel := fmt.Sprintf("N %d", config.TemplateConfig.TargetRunlevel)
+		if runlevel == targetRunlevel {
 			log.Printf("Container finished init.")
 			break
 		}

--- a/builder/lxc/template_config.go
+++ b/builder/lxc/template_config.go
@@ -6,9 +6,10 @@ import (
 )
 
 type TemplateConfig struct {
-	Name       string   `mapstructure:"template_name"`
-	Parameters []string `mapstructure:"template_parameters"`
-	EnvVars    []string `mapstructure:"template_environment_vars"`
+	Name           string   `mapstructure:"template_name"`
+	Parameters     []string `mapstructure:"template_parameters"`
+	EnvVars        []string `mapstructure:"template_environment_vars"`
+	TargetRunlevel int      `mapstructure:"target_runlevel"`
 }
 
 func (c *TemplateConfig) Prepare(t *packer.ConfigTemplate) []error {


### PR DESCRIPTION
Ubuntu has a default runlevel of 2, not 3 as Debian does.
