### PR TITLE
Correct out of range issue if runlevel output doesn't have a space.

### DIFF
--- a/builder/lxc/step_wait_init.go
+++ b/builder/lxc/step_wait_init.go
@@ -82,7 +82,10 @@ func (s *StepWaitInit) waitForInit(state multistep.StateBag, cancel <-chan struc
 		}
 
 		runlevel, _ := comm.CheckInit()
-		currentRunlevel := strings.Split(runlevel, " ")[1]
+		currentRunlevel := "unknown"
+		if arr := strings.Split(runlevel, " ") ; len(arr) >= 2 {
+			currentRunlevel = arr[1]
+		}
 
 		log.Printf("Current runlevel in container: '%s'", runlevel)
 


### PR DESCRIPTION
Seems I was too quick a few days ago. In my defense, it was my first Go code ever written. Here's a more proper fix.
