### PR TITLE
Use /. to avoid cp to automatically creating a subdirectory.

### DIFF
--- a/builder/lxc/communicator.go
+++ b/builder/lxc/communicator.go
@@ -80,7 +80,7 @@ func (c *LxcAttachCommunicator) UploadDir(dst string, src string, exclude []stri
 	// TODO: remove any file copied if it appears in `exclude`
 	dest := filepath.Join(c.RootFs, dst)
 	log.Printf("Uploading directory '%s' to rootfs '%s'", src, dest)
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("sudo cp -R %s %s", src, dest))
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("sudo cp -R %s/. %s", src, dest))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The expected semantics is that the source directory becomes the
target directory. This works for that when the target directory
already exists, and when it don't.
